### PR TITLE
Issue #9 Fixed (Bug)

### DIFF
--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -18,6 +18,11 @@ class Landing extends Component {
     this.setState({ mode: 'sign-in' })
   }
 
+  onClickRegister = (event) => {
+    event.preventDefault()
+    this.setState({ mode: 'register' })
+  }
+
   componentDidMount() {
     let videoContainer = document.getElementById('video')
     ReactDOM.render(<Video />, videoContainer)

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -44,6 +44,10 @@ class Landing extends Component {
       return (
         <React.Fragment>
           <SignInForm />
+          <div className='line-divider'></div>
+          <p>New user? Click the button below to register.</p>
+          <button type='submit' className='register-button' onClick={ this.onClickRegister }>REGISTER</button>
+          <p></p>
         </React.Fragment>
       )
     }

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -27,6 +27,7 @@ class Landing extends Component {
     let videoContainer = document.getElementById('video')
     ReactDOM.render(<Video />, videoContainer)
   }
+
   renderWelcomeContainer = () => {
     if (this.state.mode === 'register') {
       return (

--- a/src/components/SignInForm.js
+++ b/src/components/SignInForm.js
@@ -46,10 +46,6 @@ class SignInForm extends Component {
             </form>
           </div>
         </div>
-        <div className='line-divider'></div>
-        <p>New user? Click the button below to register.</p>
-        <button type='submit' className='register-button' onClick={ this.renderRegisterForm }>REGISTER</button>
-        <p></p>
       </React.Fragment>
     )
   }

--- a/src/components/SignInForm.js
+++ b/src/components/SignInForm.js
@@ -27,11 +27,6 @@ class SignInForm extends Component {
     // window.location.assign('/dashboard')
   }
 
-  renderRegisterForm = (event) => {
-    let welcomeContainer = document.getElementById('landing-container')
-    window.location.reload()
-  }
-
   render() {
     return (
       <React.Fragment>

--- a/src/components/SignInForm.js
+++ b/src/components/SignInForm.js
@@ -41,7 +41,6 @@ class SignInForm extends Component {
             <form className='signin-form'>
               <input required className='data-field' id='signin-email'    type='email'    placeholder='EMAIL'    onChange={ this.updateUser.bind(this, 'email') } />
               <input required className='data-field' id='signin-password' type='password' placeholder='PASSWORD' onChange={ this.updateUser.bind(this, 'password') } />
-
               <Link to={{ pathname: '/dashboard',  state: this.state.email }} className='signin-button'>SIGN IN</Link>
             </form>
           </div>


### PR DESCRIPTION
Fixes issue #9 - User can now view the register form when clicking on 'REGISTER' while viewing the sign in form.

Currently if a user is on the landing page and clicks sign in, the sign in form renders. But the register button under the sign in form is broken and does not render the original welcome form with the register inputs and register and sign in button.

Current temporary fix is to refresh the page.